### PR TITLE
Fixed QS status bar paddings.

### DIFF
--- a/overlay/frameworks/base/packages/SystemUI/res/values/dimens.xml
+++ b/overlay/frameworks/base/packages/SystemUI/res/values/dimens.xml
@@ -43,4 +43,8 @@
     <!-- Microns/ums (1000 um = 1mm) per pixel for the given device. If unspecified, UI that
          relies on this value will not be sized correctly. -->
     <item name="pixel_pitch" format="float" type="dimen">49.3</item>
+
+    <!-- QS Panel status bar padding fix. -->
+    <dimen name="large_screen_shade_header_left_padding">28dp</dimen>
+    <dimen name="hover_system_icons_container_padding_end">10dp</dimen>
 </resources>


### PR DESCRIPTION
![photo_2025-02-02_06-04-30](https://github.com/user-attachments/assets/31d636ed-e276-43f1-9425-5700f3120cd9)
Changed only the paddings that are shown with the arrows.